### PR TITLE
fix(renovate): remove package group

### DIFF
--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -19,43 +19,6 @@
   "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "groupName": "unifiedjs",
-      "matchPackageNames": [
-        "unified"
-      ],
-      "matchPackagePatterns": [
-        "remark",
-        "rehype",
-        "retext",
-        "redot",
-        "unist",
-        "mdast",
-        "hast",
-        "xast",
-        "esast",
-        "nlcst"
-      ]
-    },
-    {
-      "groupName": "svelte",
-      "matchPackageNames": [
-        "svelte",
-        "svelte-check"
-      ],
-      "matchPackagePrefixes": [
-        "@sveltejs"
-      ]
-    },
-    {
-      "groupName": "vite-plugin-pwa",
-      "matchPackageNames": [
-        "vite-plugin-pwa"
-      ],
-      "matchPackagePrefixes": [
-        "@vite-pwa"
-      ]
-    },
-    {
       "matchManagers": [
         "github-actions"
       ],

--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -14,6 +14,5 @@
   "major": {
     "automerge": false
   },
-  "minimumReleaseAge": "7 days",
-  "internalChecksFilter": "flexible"
+  "minimumReleaseAge": "7 days"
 }

--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -15,6 +15,5 @@
     "automerge": false
   },
   "minimumReleaseAge": "7 days",
-  "prCreation": "immediate",
   "internalChecksFilter": "flexible"
 }

--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -16,7 +16,7 @@
   },
   "minimumReleaseAge": "7 days",
   "prCreation": "immediate",
-  "internalChecksFilter": "strict",
+  "internalChecksFilter": "flexible",
   "packageRules": [
     {
       "matchManagers": [

--- a/packages/renovate/default.json
+++ b/packages/renovate/default.json
@@ -16,13 +16,5 @@
   },
   "minimumReleaseAge": "7 days",
   "prCreation": "immediate",
-  "internalChecksFilter": "flexible",
-  "packageRules": [
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "minimumReleaseAge": "3 days"
-    }
-  ]
+  "internalChecksFilter": "flexible"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration: relaxed internal checks from "strict" to "flexible", removed package grouping rules for unifiedjs, Svelte, and Vite PWA plugin dependencies, and removed the prior GitHub Actions minimum release age rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->