### PR TITLE
feat(eslint): add SKILL.md to ignore-filename-case config

### DIFF
--- a/packages/eslint/src/configs/unicorn.js
+++ b/packages/eslint/src/configs/unicorn.js
@@ -32,6 +32,7 @@ export default createConfigs({
       files: [
         GLOB_README,
         '**/AGENTS.md',
+        '**/skill/**/SKILL.md',
         GLOB_MARKDOWN_CODE_BLOCK,
         '**/*env.d.ts',
       ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude specific documentation files from filename-case validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->