### PR TITLE
feat(eslint): remove code-width rules

### DIFF
--- a/packages/eslint/src/configs/stylistic.js
+++ b/packages/eslint/src/configs/stylistic.js
@@ -8,15 +8,6 @@ export default createConfigs({
     {
       name: 'general',
       rules: {
-        'style/max-len': [
-          'error',
-          {
-            code: 100,
-            tabWidth: 2,
-            comments: 120,
-            ignoreUrls: true,
-          },
-        ],
         'style/brace-style': [
           'error',
           '1tbs',

--- a/packages/eslint/src/index.js
+++ b/packages/eslint/src/index.js
@@ -1,5 +1,4 @@
-import antfu, { GLOB_JS, GLOB_JSX, isPackageInScope } from '@antfu/eslint-config'
-import { isPackageExists } from 'local-pkg'
+import antfu, { GLOB_JS, GLOB_JSX } from '@antfu/eslint-config'
 import astro from './configs/astro.js'
 import base from './configs/base.js'
 import perfectionist from './configs/perfectionist.js'
@@ -17,30 +16,6 @@ async function mouse(options, ...userConfigs) {
     },
     stylistic: true,
     ...options,
-  }
-
-  if (options.formatters === true || typeof options.formatters === 'object') {
-    options.formatters = typeof options.formatters === 'boolean' ? {} : options.formatters
-
-    /**
-     * @see https://github.com/antfu/eslint-config/blob/f6d1a566fbe3d76a9fdc12dcba87302b5f0c9301/src/configs/formatters.ts#L30-L39
-     */
-    const isPrettierPluginXmlInScope = isPackageInScope('@prettier/plugin-xml')
-    options.formatters = {
-      astro: isPackageInScope('prettier-plugin-astro'),
-      css: true,
-      graphql: true,
-      html: true,
-      markdown: true,
-      slidev: isPackageExists('@slidev/cli'),
-      svg: isPrettierPluginXmlInScope,
-      xml: isPrettierPluginXmlInScope,
-      ...options.formatters,
-    }
-    options.formatters.prettierOptions = {
-      printWidth: 100,
-      ...options.formatters.prettierOptions,
-    }
   }
 
   const configs = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed maximum line length enforcement from ESLint stylistic rules. Previously enforced a 100-character limit for code with 120-character limit for comments; this validation is now disabled.
  * Removed dynamic formatter configuration logic, simplifying ESLint initialization by eliminating package detection and formatter fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->